### PR TITLE
feat: refine catalog layout and pagination settings

### DIFF
--- a/src/app/goods/templates/goods/catalog.html
+++ b/src/app/goods/templates/goods/catalog.html
@@ -9,183 +9,269 @@
 {% block content %}
 
 <!-- Search Results Header -->
-{% if is_search %} 
-    {% if has_results %}
-    <div class="alert alert-info mb-4">
-        <h4 class="mb-0">Search results based on "{{ search_query }}"</h4>
+{% if is_search %}
+    <div class="mb-4">
+        {% if has_results %}
+        <div class="search-header-success">
+            <div class="search-header-content">
+                <i class="fas fa-search me-2"></i>
+                <h4 class="mb-0 d-inline">Search results for "<strong>{{ search_query }}</strong>"</h4>
+                <span class="badge bg-primary ms-2">{{ goods|length }} found</span>
+            </div>
+        </div>
+        {% else %}
+        <div class="search-header-empty">
+            <div class="search-header-content">
+                <i class="fas fa-inbox me-2"></i>
+                <h4 class="mb-0 d-inline">No results for "<strong>{{ search_query }}</strong>"</h4>
+            </div>
+            <p class="mb-0 mt-2 text-muted">Try searching with different keywords or browse our categories.</p>
+        </div>
+        {% endif %}
     </div>
-    {% else %}
-    <div class="alert alert-warning mb-4">
-        <h4 class="mb-0">Nothing found on "{{ search_query }}"</h4>
-        <p class="mb-0 mt-2">Try searching with different keywords or browse our categories.</p>
-    </div>
-    {% endif %} 
 {% endif %} 
 
 {% if has_results %}
-<div class="row">
-    <!-- Filter form -->
-    <div class="dropdown mb-2">
-        <button class="btn btn-secondary dropdown-toggle btn-dark" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filters</button>
-
-        <form action="{% if request.GET.q %}{% url 'goods:search' %}{% else %}{% url 'goods:index' slug_url %}{% endif %}" method="get" class="dropdown-menu bg-dark" data-bs-theme="dark">
-            <div class="form-check text-white mx-3">
-                <input class="form-check-input" type="checkbox" name="on_sale" id="flexCheckDefault" value="on" />
+<div class="catalog-container">
+    <!-- Filter Sidebar -->
+    <aside class="filter-sidebar">
+        <button class="filter-toggle d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#filterPanel">
+            <i class="fas fa-sliders-h me-2"></i>Filters
+            <i class="fas fa-chevron-down ms-auto"></i>
+        </button>
+        
+        <div id="filterPanel" class="collapse d-lg-block filter-content">
+            <form action="{% if request.GET.q %}{% url 'goods:search' %}{% else %}{% url 'goods:index' slug_url %}{% endif %}" method="get" class="filter-form">
+                <!-- Hidden search query if applicable -->
                 {% if request.GET.q %}
                 <input type="hidden" name="q" value="{{ request.GET.q }}" />
                 {% endif %}
-                <label class="form-check-label" for="flexCheckDefault"> Products on Sale </label>
-            </div>
-            <p class="text-white mx-3 mt-3">Sort by:</p>
-            <div class="form-check text-white mx-3">
-                <input class="form-check-input" type="radio" name="order_by" id="flexRadioDefault1" value="default" />
-                <label class="form-check-label" for="flexRadioDefault1"> Default </label>
-            </div>
-            <div class="form-check text-white mx-3">
-                <input class="form-check-input" type="radio" name="order_by" id="flexRadioDefault2" value="price" />
-                <label class="form-check-label" for="flexRadioDefault2"> From cheap to expensive </label>
-            </div>
-            <div class="form-check text-white mx-3">
-                <input class="form-check-input" type="radio" name="order_by" id="flexRadioDefault3" value="-price" />
-                <label class="form-check-label" for="flexRadioDefault3"> From expensive to cheap </label>
-            </div>
-            <button type="submit" class="btn btn-primary mx-3 mt-3">Apply</button>
-        </form>
-    </div>
 
-    <div class="row">
-        {% for good in highlighted_goods|default:goods %}
-        <!-- Product card -->
-        <div class="col-lg-4 col-md-6 p-4">
-            <div class="card border-primary rounded custom-shadow position-relative {% if good.is_out_of_stock %}opacity-75{% endif %}">
-                <!-- Stock status badges -->
-                {% if good.is_out_of_stock %}
-                <span class="position-absolute top-0 start-0 badge bg-secondary text-white m-2 px-2 py-1 rounded-pill shadow" style="z-index: 10">Out of Stock</span>
-                {% elif good.is_low_stock %}
-                <span class="position-absolute top-0 start-0 badge bg-warning text-dark m-2 px-2 py-1 rounded-pill shadow" style="z-index: 10">Only {{ good.quantity }} left</span>
-                {% endif %}
-
-                <!-- Discount badge in top-right corner -->
-                {% if good.discount > 0 %}
-                <span class="position-absolute top-0 end-0 badge bg-danger text-white m-2 px-2 py-1 rounded-pill shadow" style="z-index: 10"> -{{ good.discount }}% </span>
-                {% endif %}
-
-                <a href="{% url 'goods:product' good.id %}">
-                    {% if good.image %}
-                    <img src="{{ good.image.url }}" class="card-img-top {% if good.is_out_of_stock %}grayscale{% endif %}" alt="{{ good.name }}" />
-                    {% else %}
-                    <img src="{% static 'deps/images/Not found image.png' %}" class="card-img-top {% if good.is_out_of_stock %}grayscale{% endif %}" alt="{{ good.name }}" />
-                    {% endif %}
-                </a>
-                <div class="card-body">
-                    <a href="{% url 'goods:product' good.id %}">
-                        {% if is_search and good.highlighted_name %}
-                        <p class="card-title">{{ good.highlighted_name|safe }}</p>
-                        {% else %}
-                        <p class="card-title">{{ good.name }}</p>
-                        {% endif %}
-                    </a>
-                    {% if is_search and good.highlighted_description %}
-                    <p class="card-text">{{ good.highlighted_description|truncate_html:100 }}</p>
-                    {% else %}
-                    <p class="card-text">{{ good.description|truncatechars:50 }}</p>
-                    {% endif %}
-                    <p class="product_id">id: {{ good.display_id }}</p>
-
-                    <!-- Stock information -->
-                    <div class="mb-2">
-                        {% if good.is_out_of_stock %}
-                        <span class="badge bg-secondary">Out of Stock</span>
-                        {% elif good.is_low_stock %}
-                        <span class="badge bg-warning text-dark">{{ good.quantity }} available</span>
-                        {% else %}
-                        <span class="badge bg-success">{{ good.quantity }} available</span>
-                        {% endif %}
+                <!-- Sale Filter -->
+                <div class="filter-group">
+                    <h6 class="filter-title">
+                        <i class="fas fa-tag me-2"></i>Promotions
+                    </h6>
+                    <div class="form-check filter-option">
+                        <input class="form-check-input" type="checkbox" name="on_sale" id="onSaleCheck" value="on" {% if request.GET.on_sale %}checked{% endif %} />
+                        <label class="form-check-label" for="onSaleCheck">
+                            On Sale <span class="badge bg-danger ms-1">Hot</span>
+                        </label>
                     </div>
+                </div>
 
-                    <div class="d-flex justify-content-between align-items-center">
-                        <div class="price-section">
-                            {% if good.discount > 0 %}
-                            <p class="mb-0">
-                                <small class="text-muted text-decoration-line-through">${{ good.price }}</small>
-                            </p>
-                            <p class="mb-0">
-                                <strong class="text-success fs-5">${{ good.get_discounted_price }}</strong>
-                            </p>
+                <!-- Sort Filter -->
+                <div class="filter-group">
+                    <h6 class="filter-title">
+                        <i class="fas fa-sort me-2"></i>Sort By
+                    </h6>
+                    <div class="form-check filter-option">
+                        <input class="form-check-input" type="radio" name="order_by" id="sortDefault" value="default" {% if not request.GET.order_by or request.GET.order_by == 'default' %}checked{% endif %} />
+                        <label class="form-check-label" for="sortDefault">
+                            Most Relevant
+                        </label>
+                    </div>
+                    <div class="form-check filter-option">
+                        <input class="form-check-input" type="radio" name="order_by" id="sortPriceAsc" value="price" {% if request.GET.order_by == 'price' %}checked{% endif %} />
+                        <label class="form-check-label" for="sortPriceAsc">
+                            <i class="fas fa-arrow-up me-1"></i>Price: Low to High
+                        </label>
+                    </div>
+                    <div class="form-check filter-option">
+                        <input class="form-check-input" type="radio" name="order_by" id="sortPriceDesc" value="-price" {% if request.GET.order_by == '-price' %}checked{% endif %} />
+                        <label class="form-check-label" for="sortPriceDesc">
+                            <i class="fas fa-arrow-down me-1"></i>Price: High to Low
+                        </label>
+                    </div>
+                </div>
+
+                <!-- Apply Button -->
+                <button type="submit" class="btn btn-primary w-100 filter-apply-btn">
+                    <i class="fas fa-check me-2"></i>Apply Filters
+                </button>
+            </form>
+        </div>
+    </aside>
+
+    <!-- Products Grid -->
+    <div class="products-section">
+        <div class="products-grid">
+            {% for good in highlighted_goods|default:goods %}
+            <!-- Product Card -->
+            <div class="product-card-wrapper">
+                <div class="product-card {% if good.is_out_of_stock %}is-out-of-stock{% endif %}">
+                    <!-- Image Container -->
+                    <div class="product-image-container">
+                        <a href="{% url 'goods:product' good.id %}" class="product-image-link">
+                            {% if good.image %}
+                            <img src="{{ good.image.url }}" class="product-image {% if good.is_out_of_stock %}grayscale{% endif %}" alt="{{ good.name }}" />
                             {% else %}
-                            <p class="mb-0">
-                                <strong class="fs-5">${{ good.price }}</strong>
-                            </p>
+                            <img src="{% static 'deps/images/Not found image.png' %}" class="product-image {% if good.is_out_of_stock %}grayscale{% endif %}" alt="{{ good.name }}" />
+                            {% endif %}
+                        </a>
+                        
+                        <!-- Overlay with Quick Actions -->
+                        <div class="product-overlay">
+                            <a href="{% url 'goods:product' good.id %}" class="btn btn-sm btn-light btn-view">
+                                <i class="fas fa-eye me-1"></i>Quick View
+                            </a>
+                        </div>
+
+                        <!-- Stock Badges -->
+                        <div class="badges-container">
+                            {% if good.is_out_of_stock %}
+                            <span class="badge badge-stock-out">
+                                <i class="fas fa-times-circle me-1"></i>Out of Stock
+                            </span>
+                            {% elif good.is_low_stock %}
+                            <span class="badge badge-stock-low">
+                                <i class="fas fa-exclamation-triangle me-1"></i>Only {{ good.quantity }} left
+                            </span>
+                            {% endif %}
+
+                            {% if good.discount > 0 %}
+                            <span class="badge badge-discount">
+                                -{{ good.discount }}%
+                            </span>
                             {% endif %}
                         </div>
-                        {% if good.is_out_of_stock %}
-                        <button class="btn btn-secondary" disabled><img class="mx-1" src="{% static "deps/icons/cart-plus.svg" %}" alt="Catalog Icon" width="32" height="32"></button>
-                        {% else %}
-                        <a href="{% url 'carts:cart_add' %}" class="btn add-to-cart" data-good-id="{{ good.id }}">
-                            {% csrf_token %} <img class="mx-1" src="{% static "deps/icons/cart-plus.svg" %}" alt="Catalog Icon" width="32" height="32">
+                    </div>
+
+                    <!-- Card Body -->
+                    <div class="product-body">
+                        <a href="{% url 'goods:product' good.id %}" class="product-title-link">
+                            <h5 class="product-title">
+                                {% if is_search and good.highlighted_name %}
+                                {{ good.highlighted_name|safe }}
+                                {% else %}
+                                {{ good.name }}
+                                {% endif %}
+                            </h5>
                         </a>
-                        {% endif %}
+
+                        <div class="product-description">
+                            {% if is_search and good.highlighted_description %}
+                            {{ good.highlighted_description|truncate_html:100 }}
+                            {% else %}
+                            {{ good.description|truncatechars:50 }}
+                            {% endif %}
+                        </div>
+
+                        <p class="product-id"><small>SKU: {{ good.display_id }}</small></p>
+
+                        <!-- Stock Information Bar -->
+                        <div class="stock-info-bar">
+                            {% if good.is_out_of_stock %}
+                            <div class="stock-bar stock-empty"></div>
+                            <span class="stock-text">Out of Stock</span>
+                            {% elif good.is_low_stock %}
+                            <div class="stock-bar stock-low"></div>
+                            <span class="stock-text">{{ good.quantity }} in stock</span>
+                            {% else %}
+                            <div class="stock-bar stock-available"></div>
+                            <span class="stock-text">In stock</span>
+                            {% endif %}
+                        </div>
+
+                        <!-- Footer: Price & Action -->
+                        <div class="product-footer">
+                            <div class="price-section">
+                                {% if good.discount > 0 %}
+                                <div class="price-group">
+                                    <span class="price-original">${{ good.price }}</span>
+                                    <span class="price-current">${{ good.get_discounted_price }}</span>
+                                </div>
+                                {% else %}
+                                <div class="price-group">
+                                    <span class="price-current">${{ good.price }}</span>
+                                </div>
+                                {% endif %}
+                            </div>
+
+                            {% if good.is_out_of_stock %}
+                            <button class="btn btn-cart btn-disabled" disabled>
+                                <i class="fas fa-shopping-cart"></i>
+                            </button>
+                            {% else %}
+                            <a href="{% url 'carts:cart_add' %}" class="btn btn-cart btn-active add-to-cart" data-good-id="{{ good.id }}" title="Add to cart">
+                                {% csrf_token %}
+                                <i class="fas fa-shopping-cart"></i>
+                            </a>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>
+            {% endfor %}
         </div>
-        {% endfor %}
     </div>
 </div>
 {% endif %}
 
 <!-- Pagination -->
 {% if page_obj.paginator.num_pages > 1 %}
-<nav aria-label="Page navigation">
-    <ul class="pagination justify-content-center my-4">
-        <div class="custom-shadow d-flex">
+<div class="pagination-wrapper">
+    <nav aria-label="Page navigation" class="mt-5">
+        <ul class="pagination justify-content-center pagination-custom">
             <!-- Previous button -->
             <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
-                <a
-                    class="page-link"
-                    href="{% if page_obj.has_previous %}?page={{ page_obj.previous_page_number }}{% if on_sale %}&on_sale={{ on_sale }}{% endif %}{% if order_by and order_by != 'default' %}&order_by={{ order_by }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% else %}#{% endif %}"
-                >
-                    Previous
+                <a class="page-link" href="{% if page_obj.has_previous %}?page={{ page_obj.previous_page_number }}{% if on_sale %}&on_sale={{ on_sale }}{% endif %}{% if order_by and order_by != 'default' %}&order_by={{ order_by }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% else %}#{% endif %}">
+                    <i class="fas fa-chevron-left"></i> Previous
                 </a>
             </li>
 
             <!-- Page numbers -->
-            {% for page in page_obj.paginator.page_range %} {% if page >= page_obj.number|add:-2 and page <= page_obj.number|add:2 %}
-            <li class="page-item {% if page == page_obj.number %}active{% endif %}">
-                <a
-                    class="page-link"
-                    href="?page={{ page }}{% if on_sale %}&on_sale={{ on_sale }}{% endif %}{% if order_by and order_by != 'default' %}&order_by={{ order_by }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
-                    >{{ page }}</a
-                >
-            </li>
-            {% endif %} {% endfor %}
+            {% for page in page_obj.paginator.page_range %}
+                {% if page >= page_obj.number|add:-2 and page <= page_obj.number|add:2 %}
+                <li class="page-item {% if page == page_obj.number %}active{% endif %}">
+                    <a class="page-link" href="?page={{ page }}{% if on_sale %}&on_sale={{ on_sale }}{% endif %}{% if order_by and order_by != 'default' %}&order_by={{ order_by }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}">
+                        {{ page }}
+                    </a>
+                </li>
+                {% endif %}
+            {% endfor %}
 
             <!-- Next button -->
             <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
-                <a
-                    class="page-link"
-                    href="{% if page_obj.has_next %}?page={{ page_obj.next_page_number }}{% if on_sale %}&on_sale={{ on_sale }}{% endif %}{% if order_by and order_by != 'default' %}&order_by={{ order_by }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% else %}#{% endif %}"
-                >
-                    Next
+                <a class="page-link" href="{% if page_obj.has_next %}?page={{ page_obj.next_page_number }}{% if on_sale %}&on_sale={{ on_sale }}{% endif %}{% if order_by and order_by != 'default' %}&order_by={{ order_by }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% else %}#{% endif %}">
+                    Next <i class="fas fa-chevron-right"></i>
                 </a>
             </li>
-        </div>
-    </ul>
-</nav>
+        </ul>
+    </nav>
+</div>
 {% endif %}
 
 <script>
     document.addEventListener("DOMContentLoaded", function () {
-        // Prevent dropdown from closing when clicking inside it
-        document.querySelectorAll(".dropdown-menu").forEach(function (dropdown) {
-            dropdown.addEventListener("click", function (e) {
-                e.stopPropagation();
+        // Handle filter sidebar toggle on mobile
+        const filterToggle = document.querySelector(".filter-toggle");
+        const filterPanel = document.getElementById("filterPanel");
+        
+        if (filterToggle) {
+            filterToggle.addEventListener("click", function () {
+                this.classList.toggle("active");
             });
+        }
+
+        // Prevent filter dropdown from closing when clicking inside it
+        filterPanel?.addEventListener("click", function (e) {
+            if (e.target.tagName !== "BUTTON") {
+                e.stopPropagation();
+            }
         });
 
-        // Allow dropdown to close when clicking Apply button
-        document.querySelector('.dropdown-menu button[type="submit"]').addEventListener("click", function (e) {
-            // Form will submit and page will reload, so dropdown will close naturally
+        // Add to cart animation
+        document.querySelectorAll(".add-to-cart").forEach(function (btn) {
+            btn.addEventListener("click", function (e) {
+                e.preventDefault();
+                const btn = e.target.closest(".add-to-cart");
+                btn.classList.add("adding");
+                
+                setTimeout(() => {
+                    btn.classList.remove("adding");
+                }, 600);
+            });
         });
     });
 </script>

--- a/src/app/goods/views.py
+++ b/src/app/goods/views.py
@@ -10,7 +10,7 @@ class CatalogView(ListView):
     model = Products
     template_name = 'goods/catalog.html'
     context_object_name = 'goods'
-    paginate_by = 3
+    paginate_by = 4
     
     def get_queryset(self):
         # Get URL parameters

--- a/src/app/static/deps/css/my_css.css
+++ b/src/app/static/deps/css/my_css.css
@@ -7,11 +7,757 @@ body {
     height: 100%;
 }
 
-/* Stock status styles */
-.grayscale {
-    filter: grayscale(100%);
-    transition: filter 0.3s ease;
+/* ===== CATALOG PAGE STYLES ===== */
+
+/* Search Header Styles */
+.search-header-success,
+.search-header-empty {
+    padding: 1.5rem;
+    border-radius: 12px;
+    margin-bottom: 2rem;
+    border-left: 4px solid;
+    animation: slideInDown 0.4s ease-out;
 }
+
+.search-header-success {
+    background: linear-gradient(135deg, #e8f4f8 0%, #f0f9fc 100%);
+    border-left-color: #0d6efd;
+}
+
+.search-header-empty {
+    background: linear-gradient(135deg, #fff3cd 0%, #fffbea 100%);
+    border-left-color: #ffc107;
+}
+
+.search-header-content {
+    display: flex;
+    align-items: center;
+    font-weight: 500;
+}
+
+.search-header-content i {
+    font-size: 1.5rem;
+    margin-right: 1rem;
+    opacity: 0.8;
+}
+
+/* Catalog Container */
+.catalog-container {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+/* Filter Sidebar */
+.filter-sidebar {
+    position: sticky;
+    top: 100px;
+    height: fit-content;
+}
+
+.filter-toggle {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: #fff;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    font-weight: 600;
+    color: #212529;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    transition: all 0.3s ease;
+    margin-bottom: 1rem;
+}
+
+.filter-toggle:hover,
+.filter-toggle.active {
+    background: #212529;
+    color: white;
+    border-color: #212529;
+}
+
+.filter-content {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 15px rgba(0, 0, 0, 0.08);
+    animation: slideInLeft 0.3s ease-out;
+}
+
+.filter-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #e9ecef;
+    align-items: center;
+}
+
+.filter-group:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.filter-title {
+    font-weight: 600;
+    color: #212529;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    font-size: 0.95rem;
+    width: 100%;
+}
+
+.filter-title i {
+    margin-right: 0.5rem;
+    color: #0d6efd;
+}
+
+.filter-option {
+    margin: 0;
+    padding: 0.5rem 0;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    justify-content: flex-start;
+}
+
+.filter-option:hover {
+    transform: translateX(4px);
+}
+
+.filter-option .form-check-input {
+    width: 18px;
+    height: 18px;
+    border: 2px solid #dee2e6;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    margin: 0;
+    flex-shrink: 0;
+}
+
+.filter-option .form-check-input:checked {
+    background-color: #0d6efd;
+    border-color: #0d6efd;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.filter-option .form-check-label {
+    cursor: pointer;
+    font-weight: 500;
+    color: #495057;
+    margin-left: 0.75rem;
+    transition: color 0.2s ease;
+    user-select: none;
+}
+
+.filter-option:hover .form-check-label {
+    color: #212529;
+}
+
+.filter-apply-btn {
+    padding: 0.875rem 1.5rem;
+    font-weight: 600;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #0d6efd 0%, #0a58ca 100%);
+    border: none;
+    transition: all 0.3s ease;
+    margin-top: 0.5rem;
+}
+
+.filter-apply-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(13, 110, 253, 0.4);
+}
+
+.filter-apply-btn:active {
+    transform: translateY(0);
+}
+
+/* Products Section */
+.products-section {
+    display: flex;
+    flex-direction: column;
+}
+
+.products-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+    animation: fadeIn 0.4s ease-out;
+}
+
+/* Product Card Wrapper & Card */
+.product-card-wrapper {
+    animation: scaleIn 0.4s ease-out;
+}
+
+.product-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    border: 1px solid #f0f0f0;
+}
+
+.product-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+    border-color: #e9ecef;
+}
+
+.product-card.is-out-of-stock {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+/* Product Image Container */
+.product-image-container {
+    position: relative;
+    width: 100%;
+    padding-bottom: 100%;
+    overflow: hidden;
+    background: #f8f9fa;
+}
+
+.product-image-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.product-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.product-card:hover .product-image {
+    transform: scale(1.08);
+}
+
+.product-image.grayscale {
+    filter: grayscale(100%);
+}
+
+/* Product Overlay */
+.product-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(33, 37, 41, 0.7);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 1.5rem;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.product-card:hover .product-overlay {
+    opacity: 1;
+}
+
+.btn-view {
+    background: white !important;
+    color: #212529 !important;
+    font-weight: 600;
+    transform: translateY(10px);
+    transition: all 0.3s ease;
+}
+
+.product-card:hover .btn-view {
+    transform: translateY(0);
+}
+
+.btn-view:hover {
+    background: #0d6efd !important;
+    color: white !important;
+    transform: translateY(0) scale(1.05);
+}
+
+/* Badge Container */
+.badges-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 5;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 6px;
+    animation: slideInRight 0.3s ease-out;
+}
+
+.badge-stock-out {
+    background: #dc3545;
+    color: white;
+}
+
+.badge-stock-low {
+    background: #ffc107;
+    color: #000;
+}
+
+.badge-discount {
+    background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
+    color: white;
+    font-size: 0.9rem;
+    margin-left: auto;
+}
+
+/* Product Body */
+.product-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    padding: 1.25rem;
+    gap: 0.75rem;
+}
+
+.product-title-link {
+    text-decoration: none;
+    color: inherit;
+}
+
+.product-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #212529;
+    margin: 0;
+    line-height: 1.3;
+    transition: color 0.2s ease;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.product-title-link:hover .product-title {
+    color: #0d6efd;
+}
+
+.product-description {
+    font-size: 0.875rem;
+    color: #6c757d;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.product-id {
+    font-size: 0.75rem;
+    color: #adb5bd;
+    margin: 0;
+}
+
+/* Stock Information Bar */
+.stock-info-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0.25rem 0;
+}
+
+.stock-bar {
+    flex: 1;
+    height: 5px;
+    background: #e9ecef;
+    border-radius: 3px;
+    overflow: hidden;
+    position: relative;
+}
+
+.stock-bar::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    animation: fillProgress 0.6s ease-out forwards;
+}
+
+.stock-bar.stock-empty::after {
+    background: #dc3545;
+    width: 0;
+}
+
+.stock-bar.stock-low::after {
+    background: linear-gradient(90deg, #ffc107 0%, #ff9800 100%);
+    width: 40%;
+}
+
+.stock-bar.stock-available::after {
+    background: linear-gradient(90deg, #28a745 0%, #20c997 100%);
+    width: 100%;
+}
+
+.stock-text {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #6c757d;
+    white-space: nowrap;
+}
+
+/* Product Footer */
+.product-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid #f0f0f0;
+    margin-top: auto;
+}
+
+.price-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.price-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.price-original {
+    font-size: 0.85rem;
+    color: #adb5bd;
+    text-decoration: line-through;
+    font-weight: 500;
+}
+
+.price-current {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #0d6efd;
+    letter-spacing: -0.5px;
+}
+
+/* Add to Cart Button */
+.btn-cart {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    border: 2px solid transparent;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    cursor: pointer;
+}
+
+.btn-cart.btn-active {
+    background: linear-gradient(135deg, #0d6efd 0%, #0a58ca 100%);
+    color: white;
+    border-color: transparent;
+}
+
+.btn-cart.btn-active:hover {
+    transform: scale(1.1);
+    box-shadow: 0 4px 12px rgba(13, 110, 253, 0.4);
+}
+
+.btn-cart.btn-active:active {
+    transform: scale(0.95);
+}
+
+.btn-cart.btn-active.adding {
+    animation: buttonPulse 0.6s ease-out;
+}
+
+.btn-cart.btn-disabled {
+    background: #e9ecef;
+    color: #6c757d;
+    cursor: not-allowed;
+    border-color: #dee2e6;
+}
+
+/* Pagination Styles */
+.pagination-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 3rem;
+    animation: fadeIn 0.4s ease-out;
+}
+
+.pagination-custom {
+    gap: 0.5rem;
+}
+
+.pagination-custom .page-link {
+    border: 1px solid #dee2e6;
+    color: #212529;
+    background: white;
+    border-radius: 6px;
+    padding: 0.6rem 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.pagination-custom .page-link:hover:not(.disabled) {
+    background: #0d6efd;
+    color: white;
+    border-color: #0d6efd;
+    transform: translateY(-2px);
+}
+
+.pagination-custom .page-item.active .page-link {
+    background: linear-gradient(135deg, #0d6efd 0%, #0a58ca 100%);
+    border-color: #0d6efd;
+    color: white;
+}
+
+.pagination-custom .page-item.disabled .page-link {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ===== ANIMATIONS ===== */
+
+@keyframes slideInDown {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes slideInLeft {
+    from {
+        opacity: 0;
+        transform: translateX(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes slideInRight {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes scaleIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes fillProgress {
+    from {
+        width: 0;
+    }
+}
+
+@keyframes buttonPulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(13, 110, 253, 0.7);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(13, 110, 253, 0);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(13, 110, 253, 0);
+    }
+}
+
+/* ===== RESPONSIVE DESIGN ===== */
+
+@media (max-width: 1024px) {
+    .catalog-container {
+        grid-template-columns: 1fr;
+    }
+
+    .products-grid {
+        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    }
+
+    .filter-sidebar {
+        position: static;
+    }
+
+    .filter-content {
+        animation: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .filter-toggle {
+        display: flex;
+    }
+
+    .filter-content {
+        max-height: 0;
+        overflow: hidden;
+        padding: 0;
+        transition: max-height 0.3s ease, padding 0.3s ease;
+    }
+
+    .filter-content.show {
+        max-height: 1000px;
+        padding: 1.5rem;
+    }
+
+    .products-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+    }
+
+    .product-body {
+        padding: 1rem;
+    }
+
+    .product-title {
+        font-size: 0.95rem;
+    }
+
+    .product-description {
+        font-size: 0.8rem;
+    }
+
+    .price-current {
+        font-size: 1.1rem;
+    }
+
+    .pagination-custom .page-link {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.9rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .products-grid {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+    }
+
+    .product-body {
+        padding: 0.75rem;
+        gap: 0.5rem;
+    }
+
+    .product-title {
+        font-size: 0.85rem;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+    }
+
+    .product-description {
+        font-size: 0.75rem;
+        display: none;
+    }
+
+    .product-id {
+        display: none;
+    }
+
+    .product-footer {
+        gap: 0.5rem;
+        padding-top: 0.5rem;
+    }
+
+    .btn-cart {
+        width: 38px;
+        height: 38px;
+        font-size: 0.9rem;
+    }
+
+    .price-current {
+        font-size: 1rem;
+    }
+
+    .price-original {
+        font-size: 0.75rem;
+    }
+
+    .stock-info-bar {
+        display: none;
+    }
+
+    .pagination-custom .page-link {
+        padding: 0.5rem;
+        font-size: 0.8rem;
+        min-width: 40px;
+    }
+
+    .search-header-content {
+        flex-wrap: wrap;
+    }
+
+    .search-header-content i {
+        font-size: 1.25rem;
+    }
+}
+
+/* Old styles preserved for compatibility */
 
 .opacity-75 {
     opacity: 0.75;


### PR DESCRIPTION
- Display 4 items per page in 2x2 grid layout (paginate_by: 3→4)
- Fix grid to use fixed 2-column layout instead of auto-fill
- Center-align filter group titles with left-aligned options
- Improved responsive grid for tablet and mobile views